### PR TITLE
Removed protected_attributes gem, use Rails 4 strong parameters.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,6 @@ source 'https://rubygems.org'
 
 gem 'rails', '~> 4.2'
 gem 'friendly_id', '~> 5.1.0'
-# Temporary Rails 4 fix. See e.g. http://www.sitepoint.com/rails-4-quick-look-strong-parameters/
-gem 'protected_attributes'
 
 # Bundle edge Rails instead:
 # gem 'rails', :git => 'git://github.com/rails/rails.git'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -225,8 +225,6 @@ GEM
     opal-rspec (0.4.3)
       opal (>= 0.7.0, < 0.9)
     orm_adapter (0.5.0)
-    protected_attributes (1.1.3)
-      activemodel (>= 4.0.1, < 5.0)
     rack (1.6.4)
     rack-protection (1.5.3)
       rack
@@ -415,7 +413,6 @@ DEPENDENCIES
   omniauth-github
   omniauth-google-oauth2
   opal-rails
-  protected_attributes
   rails (~> 4.2)
   rails_best_practices
   rjgit (~> 4.0)

--- a/TODO.md
+++ b/TODO.md
@@ -42,7 +42,7 @@
 # VALIDATIONS & SANITIZATION
 - [x] Repository name is unique for owner
 - [ ] datadir config option has default characters
-- [ ] remove `attr_accessible` from models, remove `attr_accessible` gem, and replace with Strong Parameters. See http://www.sitepoint.com/rails-4-quick-look-strong-parameters/
+- [x] remove `attr_accessible` from models, remove `attr_accessible` gem, and replace with Strong Parameters. See [here](http://www.sitepoint.com/rails-4-quick-look-strong-parameters/)
 
 # SYNCHRONIZATION
 - [ ] Work out a way to update the 'updated-at' field of a repository in ActiveRecord each time a commit is made through the git servlet.

--- a/app/controllers/admin/repositories_controller.rb
+++ b/app/controllers/admin/repositories_controller.rb
@@ -1,6 +1,8 @@
 class Admin::RepositoriesController < Admin::AdminController
   load_and_authorize_resource :except => [:index, :new, :create]
 
+  include Params::RepoParams
+
   # GET /repositories
   # GET /repositories.json
   def index
@@ -33,7 +35,7 @@ class Admin::RepositoriesController < Admin::AdminController
   # PUT /repositories/1.json
   def update
     respond_to do |format|
-      if @repository.update_attributes(params[:repository])
+      if @repository.update_attributes(repo_params)
         format.html { redirect_to [@repository.owner, @repository], notice: 'Repository was successfully updated.' }
         format.json { head :no_content }
         format.js { flash[:notice] = 'Repository was updated.'}

--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -1,5 +1,5 @@
 class Admin::SettingsController < Admin::AdminController
-  # General Settings
+  include Params::SettingParams
 
   def show_general_settings
     @general_settings = Setting.get(:general_settings)
@@ -12,13 +12,11 @@ class Admin::SettingsController < Admin::AdminController
   end
 
   def update_general_settings
-    updated_key = params[:name].to_sym
-
     valid_keys = [:repo_root, :archive_root, :wiki_root, :server_domain, :server_port, :anonymous_access, :public_profiles, :enable_wikis, :enable_issuetracker, :default_branch]
-    if valid_keys.include?(updated_key)
+    if valid_keys.include?(@updated_key)
 
       @general_settings = Setting.get(:general_settings)
-      @general_settings[updated_key] = params[:value]
+      @general_settings[@updated_key] = @value
       @general_settings.save
       render '/admin/settings/general/show'
     end
@@ -35,14 +33,12 @@ class Admin::SettingsController < Admin::AdminController
   end
   
   def update_authentication_settings
-    updated_key = params[:name].to_sym
-
     valid_keys = [:google_oauth2_app_id, :google_oauth2_app_secret, :google_oauth2_enabled, :facebook_app_id, :facebook_app_secret, :facebook_enabled, :github_app_id, :github_app_secret, :github_enabled]
-    if valid_keys.include?(updated_key)
-      provider = updated_key.to_s.split('_').first
+    if valid_keys.include?(@updated_key)
+      provider = @updated_key.to_s.split('_').first
       provider = (provider == 'google' ? 'google_oauth2' : provider) 
       @authentication_settings = Setting.get(:authentication_settings)
-      @authentication_settings[provider.to_sym][updated_key] = params[:value]
+      @authentication_settings[provider.to_sym][@updated_key] = @value
       @authentication_settings.save
       Rails.logger.debug @authentication_settings.errors.inspect
       render '/admin/settings/authentication/show'
@@ -62,15 +58,11 @@ class Admin::SettingsController < Admin::AdminController
   end
 
   def update_smtp_settings
-    Rails.logger.debug params
-    updated_key = params[:name].to_sym
-    Rails.logger.debug updated_key
-
     valid_keys = [:address, :port, :domain, :user_name, :password, :authentication, :enable_starttls_auto]
-    if valid_keys.include?(updated_key)
+    if valid_keys.include?(@updated_key)
 
       @smtp_settings = Setting.get(:smtp_settings)
-      @smtp_settings[updated_key] = params[:value]
+      @smtp_settings[@updated_key] = @value
       @smtp_settings.save
       if Repotag::Application.config.action_mailer.smtp_settings.nil?
         Repotag::Application.config.action_mailer.smtp_settings = @smtp_settings.settings

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,6 +1,8 @@
 class Admin::UsersController < Admin::AdminController
   load_and_authorize_resource :except => [:index, :new, :create]
 
+  include Params::UserParams
+
   def index
     @users = User.all
 
@@ -26,7 +28,7 @@ class Admin::UsersController < Admin::AdminController
   end
 
   def create
-    @user = User.new(params[:user])
+    @user = User.new(user_params)
     set_user_roles(@user, params["global_roles"])
 
     respond_to do |format|
@@ -42,14 +44,15 @@ class Admin::UsersController < Admin::AdminController
   end
 
   def update
-    if params[:user][:password].blank?
-      params[:user].delete(:password)
-      params[:user].delete(:password_confirmation)
+    update_params = user_params.dup
+    if update_params[:password].blank?
+      update_params.delete(:password)
+      update_params.delete(:password_confirmation)
     end
     set_user_roles(@user, params["global_roles"])
 
     respond_to do |format|
-      if @user.update_attributes(params[:user])
+      if @user.update_attributes(update_params)
         format.html { redirect_to admin_users_path, :notice => 'User was successfully updated.' }
         format.json { head :ok }
       else

--- a/app/controllers/concerns/params.rb
+++ b/app/controllers/concerns/params.rb
@@ -1,0 +1,45 @@
+# Defines strong parameters so these can be used in both admin and normal controllers
+module Params
+  module UserParams
+    extend ActiveSupport::Concern
+
+    private
+
+    def user_params
+      params.require(:user).permit(:login, :username, :name, :email, :password, :password_confirmation, :remember_me, :public)
+    end 
+  end
+
+  module SettingParams
+    extend ActiveSupport::Concern
+
+    included do
+    	before_filter :setting_params, :if => Proc.new {|controller| controller.params[:action] =~ /\Aupdate_(\w+_)?settings\z/ }
+    end
+
+    private
+
+    def setting_params
+      settings = {:name => params.require(:name), :value => params.require(:value)}
+      @value = case settings[:value]
+        when true
+          "1"
+        when false
+          "0"
+        else
+          settings[:value]
+        end
+      @updated_key = settings[:name].to_sym
+    end
+  end
+
+  module RepoParams
+    extend ActiveSupport::Concern
+
+    private
+
+    def repo_params
+      params.require(:repository).permit(:name, :public, :description)
+    end
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,26 +1,26 @@
 class UsersController < ApplicationController
   load_and_authorize_resource
-  skip_authorize_resource :only => [:show, :settings, :update_settings]
-  skip_load_resource :only => [:settings, :update_settings]
+  before_filter :find_user
+  skip_authorize_resource :only => [:settings, :update_settings]
+
+  include Params::UserParams
+  include Params::SettingParams
 
   def show
     @user_settings = @user.settings
   end
 
   def settings
-    @user = params[:user] ? User.friendly.find(params[:user]) : current_user
     authorize! :read, @user
     @user_settings = @user.settings
   end
   
   def update_settings
-    @user = params[:user] ? User.friendly.find(params[:user]) : current_user
     authorize! :update, @user
-    updated_key = params[:name].to_sym
     @user_settings = @user.settings
 
-    if User.default_settings.keys.include?(updated_key)
-      @user_settings[updated_key] = params[:value]
+    if User.default_settings.keys.include?(@updated_key)
+      @user_settings[@updated_key] = @value
       @user_settings.save
     end
     render '/users/settings'
@@ -28,7 +28,7 @@ class UsersController < ApplicationController
   
   def update
     respond_to do |format|
-      if @user.update_attributes(params[:user])
+      if @user.update_attributes(user_params)
         format.html { redirect_to @user, :notice => 'Profile was successfully updated.' }
       else
         flash_save_errors "user", @user.errors
@@ -36,4 +36,15 @@ class UsersController < ApplicationController
       end
     end
   end
+
+  private
+
+  def find_user
+    @user = params[:id] ? User.friendly.find(params[:id]) : current_user
+    if @user.nil?
+      flash[:error] = "User does not exist."
+      redirect_to :root
+    end
+  end
+
 end

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -11,8 +11,6 @@ class Repository < ActiveRecord::Base
 
   friendly_id :name, :use => :scoped, :scope => :owner
 
-  attr_accessible :name, :slug, :public, :description
-
   validates :name, :presence => true, :uniqueness => {:scope => :owner, :case_sensitive => false}, :format => {:with => /\A[\w]+\z/ , :message => "contains illegal characters"}
   validates_presence_of :owner
 

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -1,7 +1,4 @@
 class Role < ActiveRecord::Base
-
-  attr_accessible :title
-
   belongs_to :user
   belongs_to :resource, :polymorphic => true
 

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -1,7 +1,5 @@
 class Setting < ActiveRecord::Base
   serialize :settings
-  attr_accessible :settings, :name
-
   validates_presence_of :name
 
   def self.get(name)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,14 +6,9 @@ class User < ActiveRecord::Base
   has_many :repositories, :through => :roles, :source => :resource, :source_type => 'Repository'
   friendly_id :username
 
-  # Include default devise modules. Others available are:
-  # :token_authenticatable, :encryptable, :confirmable, :lockable, :timeoutable and :omniauthable
-
   devise :database_authenticatable, :recoverable, :rememberable, :trackable, :validatable, :omniauthable, :omniauth_providers => [:google_oauth2, :facebook]
 
   attr_accessor :login, :updating_password
-  # Setup accessible attributes for your model
-  attr_accessible :login, :username, :name, :email, :password, :password_confirmation, :remember_me, :encrypted_password, :provider, :uid, :public
 
   validates_uniqueness_of :username, :case_sensitive => false
   validates_presence_of :username, :format => {:with => /\A[\w]+\z/ , :message => "contains illegal characters"}

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,6 +18,7 @@ module Repotag
     # Custom directories with classes and modules you want to be autoloadable.
     # config.autoload_paths += %W(#{config.root}/extras)
     config.autoload_paths += Dir["#{config.root}/lib/assets/**/"]
+    config.autoload_paths += Dir["#{config.root}/app/controllers/concerns", "#{config.root}/app/models/concerns"]
 
     # Only load the plugins named here, in the order given (default is alphabetical).
     # :all can be used as a placeholder for all plugins not explicitly named.
@@ -44,12 +45,6 @@ module Repotag
     # This is necessary if your schema can't be completely dumped by the schema dumper,
     # like if you have constraints or database-specific column types
     # config.active_record.schema_format = :sql
-
-    # Enforce whitelist mode for mass assignment.
-    # This will create an empty whitelist of attributes available for mass-assignment for all models
-    # in your app. As such, your models will need to explicitly whitelist or blacklist accessible
-    # parameters by using an attr_accessible or attr_protected declaration.
-    # config.active_record.whitelist_attributes = true
 
     # Enable the asset pipeline
     config.assets.enabled = true

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -23,9 +23,6 @@ Repotag::Application.configure do
   # Only use best-standards-support built into browsers
   config.action_dispatch.best_standards_support = :builtin
 
-  # Raise exception on mass assignment protection for Active Record models
-  config.active_record.mass_assignment_sanitizer = :strict
-
   # Do not compress assets
   config.assets.compress = false
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -29,9 +29,6 @@ Repotag::Application.configure do
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
 
-  # Raise exception on mass assignment protection for Active Record models
-  config.active_record.mass_assignment_sanitizer = :strict
-
   # Print deprecation notices to the stderr
   config.active_support.deprecation = :stderr
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,8 +36,8 @@ Repotag::Application.routes.draw do
 
   authenticated :user do
     mount grack_auth_proxy, at: 'git', as: 'git'
-    get '/:user/settings', controller: 'users', action: 'settings'
-    put '/:user/update_settings', controller: 'users', action: 'update_settings'
+    get '/:id/settings', controller: 'users', action: 'settings'
+    put '/:id/update_settings', controller: 'users', action: 'update_settings'
   end
   mount grack_auth_proxy, at: 'git'
   mount gollum_auth_proxy, at: ':user/:repository/wiki'

--- a/spec/controllers/admin_repositories_controller_spec.rb
+++ b/spec/controllers/admin_repositories_controller_spec.rb
@@ -46,7 +46,7 @@ describe Admin::RepositoriesController, type: :controller do
     describe 'POST' do
       describe '#update' do
         before do
-          post :update, :id => repo.id
+          post :update, :id => repo.id, :repository => {:name => 'blaaa'}
         end
         it_behaves_like 'a controller action', {:template => nil, :response => 302, :redirect => /\/.+\/.+/, :layout => nil}
       end

--- a/spec/shared_examples.rb
+++ b/spec/shared_examples.rb
@@ -3,8 +3,6 @@ shared_examples_for "it controls settings" do |model|
   let(:user) { FactoryGirl.create(:user) }
   let(:route_options) { # Where to route to
     case model
-    when :user
-      {:user => instance}
     when :repository
       {:user_id => instance.owner.to_param, :repository_id => instance.to_param}
     else


### PR DESCRIPTION
The `protected_attributes` gem allowed us to use older Rails 3 style mass-assignment protection through whitelist. Rails 4 introduced strong parameters, which allows us to take mass-assignment protection out of the models and into the controllers. Moreover, using strong parameters has the advantage that we can specify required parameters for a controller action:

```
params.require(:value) # If this is called from a controller action, the action will automatically fail if the :value parameters was not specified.
```

This PR implements strong parameters for all controllers. Some strong parameter methods are abstracted to `concerns/params.rb`, so we can reuse code in the admin namespace.
